### PR TITLE
[Step 2] uses Moshi library to parse JSON response into Kotlin objects

### DIFF
--- a/app/src/main/java/com/example/android/marsrealestate/network/MarsApiService.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/network/MarsApiService.kt
@@ -22,7 +22,6 @@ import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
-import retrofit2.converter.scalars.ScalarsConverterFactory
 import retrofit2.http.GET
 
 // root address of the Mars server endpoint

--- a/app/src/main/java/com/example/android/marsrealestate/network/MarsApiService.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/network/MarsApiService.kt
@@ -17,36 +17,38 @@
 
 package com.example.android.marsrealestate.network
 
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import retrofit2.Call
 import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
 import retrofit2.http.GET
 
 // root address of the Mars server endpoint
 private const val BASE_URL = "https://mars.udacity.com/"
 
-// create a RetroFit builder
-// pass in a scalars converter that supports returning strings and other primitive types
-// specify route web address of our server's endpoint
-// call build to create the RetroFit object
+// we need to create a Moshi object usng the Moshi builder
+// we need to add the Kotlin JSON adapter factory in order for moshi's annotations to work with Kotlin
+private val moshi = Moshi.Builder()
+    .add(KotlinJsonAdapterFactory())
+    .build()
+
+// RetroFit builder
 private val retrofit = Retrofit.Builder()
-    .addConverterFactory(ScalarsConverterFactory.create())
+    // by adding a Moshi converter factory, we will let RetroFit know it can use Moshi to convert JSON into Kotlin objects
+    .addConverterFactory(MoshiConverterFactory.create(moshi))
     .baseUrl(BASE_URL)
     .build()
 
 // public interface that exposes the getProperties method
-// defines an interface that explains how retrofit talks to our web server using HTTP requests
 interface MarsApiService {
-    // getProperties gets the JSON response
-    // use the GET annotation and specify the endpoint
-    // returns a Retrofit callback that delivers a JSON string response
     @GET("realestate")
-    fun getProperties(): Call<String>
+    // update MarsApiService to return a list of MarsProperty objects
+    fun getProperties(): Call<List<MarsProperty>>
 }
 
 // public api object that exposes the lazy-initialized Retrofit service
-// to create a retrofit service, call retrofit.create passing in the service interface API
-// calling MarsApi.retrofitService will return a retrofit object implementing MarsApiService
 object MarsApi {
     val retrofitService: MarsApiService by lazy { retrofit.create(MarsApiService::class.java) }
 }

--- a/app/src/main/java/com/example/android/marsrealestate/network/MarsProperty.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/network/MarsProperty.kt
@@ -17,4 +17,15 @@
 
 package com.example.android.marsrealestate.network
 
-class MarsProperty()
+import com.squareup.moshi.Json
+
+//Moshi needs to have a class to store the parsed JSON
+//Moshi will match the property names from the MarsProperty class with the property names from the JSON response
+
+data class MarsProperty(
+    val id: String,
+    //we use the @JSON annotation to switch the name of the property to match Kotlin style
+    @Json(name = "img_src") val imgSrcUrl: String,
+    val type: String,
+    val price: Double
+)

--- a/app/src/main/java/com/example/android/marsrealestate/overview/OverviewViewModel.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/overview/OverviewViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.example.android.marsrealestate.network.MarsApi
+import com.example.android.marsrealestate.network.MarsProperty
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -53,11 +54,11 @@ class OverviewViewModel : ViewModel() {
     // callback has both success and failure methods which are called depending on if retrofit is successful in fetching the JSON
 
     private fun getMarsRealEstateProperties() {
-        // TODO (05) Call the MarsApi to enqueue the Retrofit request, implementing the callbacks
         _response.value = "Set the Mars API Response here!"
-        MarsApi.retrofitService.getProperties().enqueue(object: Callback<String> {
-            override fun onResponse(call: Call<String>, response: Response<String>) {
-                _response.value = response.body()
+        MarsApi.retrofitService.getProperties().enqueue(object: Callback<List<MarsProperty>> {
+            // we want to return the number of properties fetched
+            override fun onResponse(call: Call<String>, response: Response<List<MarsProperty>>) {
+                _response.value = "Success: ${response.body()?.size} Mars properties retrieved"
             }
 
             override fun onFailure(call: Call<String>, t: Throwable) {

--- a/app/src/main/java/com/example/android/marsrealestate/overview/OverviewViewModel.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/overview/OverviewViewModel.kt
@@ -54,14 +54,13 @@ class OverviewViewModel : ViewModel() {
     // callback has both success and failure methods which are called depending on if retrofit is successful in fetching the JSON
 
     private fun getMarsRealEstateProperties() {
-        _response.value = "Set the Mars API Response here!"
         MarsApi.retrofitService.getProperties().enqueue(object: Callback<List<MarsProperty>> {
             // we want to return the number of properties fetched
-            override fun onResponse(call: Call<String>, response: Response<List<MarsProperty>>) {
+            override fun onResponse(call: Call<List<MarsProperty>>, response: Response<List<MarsProperty>>) {
                 _response.value = "Success: ${response.body()?.size} Mars properties retrieved"
             }
 
-            override fun onFailure(call: Call<String>, t: Throwable) {
+            override fun onFailure(call: Call<List<MarsProperty>>, t: Throwable) {
                 _response.value = "Failure: " + t.message
             }
         })

--- a/app/src/main/java/com/example/android/marsrealestate/overview/OverviewViewModel.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/overview/OverviewViewModel.kt
@@ -48,10 +48,6 @@ class OverviewViewModel : ViewModel() {
     /**
      * Sets the value of the status LiveData to the Mars API status.
      */
-    // call our retrofit service
-    // call enqueue on callback to start the network request on a background thread
-    // enqueue takes a retrofit callback class as input that contains methods that will be called when the request is complete
-    // callback has both success and failure methods which are called depending on if retrofit is successful in fetching the JSON
 
     private fun getMarsRealEstateProperties() {
         MarsApi.retrofitService.getProperties().enqueue(object: Callback<List<MarsProperty>> {


### PR DESCRIPTION
This step parses JSON response into Kotlin objects

- create a mars property data class that stores the parsed JSON
- In MarsApiService.kt
   - create a Moshi object using Moshi builder
   - pass in MoshiConverterFactory to let Retrofit know it can use Moshi to convert JSON into Kotlin objects
   - update MarsApiService interface to return a list of MarsProperty objects   

-In OverviewViewModel.kt
   - update getMarsRealEstateProperties to handle a list of mars property objects
   - response prints out the number of properties fetched 