### PR TITLE
[Step 4] adds Glide library to handle the processing of the Mars image

### DIFF
--- a/app/src/main/java/com/example/android/marsrealestate/BindingAdapters.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/BindingAdapters.kt
@@ -17,3 +17,39 @@
 
 package com.example.android.marsrealestate
 
+import android.widget.ImageView
+import androidx.core.net.toUri
+import androidx.databinding.BindingAdapter
+import com.bumptech.glide.Glide
+import com.bumptech.glide.request.RequestOptions
+
+// binding adapter takes the URL from an XML attribute associated with an ImgView
+// Uses Glide to load the image
+
+// this tells data binding that we want this binding adapter executed when an XML item
+// has the imageUrl attribute
+@BindingAdapter("imageUrl")
+// the view parameter is specified as an image view
+fun bindImage(imgView: ImageView, imgUrl: String?) {
+    imgUrl?.let {
+        // convert image url to a uri
+        // make sure the resulting uri has the https scheme
+        val imgUri = it.toUri().buildUpon().scheme("https").build()
+
+        // Glide has a fluent interface
+        // to load an image with Glide
+        // pass in an android context for the img view
+        Glide.with(imgView.context)
+            .load(imgUri)
+            // Glide can help us improve the user experience by showing
+            // a placeholder image while loading the image and an error image if the loading fails
+            // Glide adds these objects to the request using a RequestOptions object
+            .apply(
+                RequestOptions()
+                .placeholder(R.drawable.loading_animation)
+                .error(R.drawable.ic_broken_image))
+            .into(imgView)
+
+    }
+
+}

--- a/app/src/main/java/com/example/android/marsrealestate/overview/OverviewFragment.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/overview/OverviewFragment.kt
@@ -23,6 +23,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.example.android.marsrealestate.R
 import com.example.android.marsrealestate.databinding.FragmentOverviewBinding
+import com.example.android.marsrealestate.databinding.GridViewItemBinding
 
 /**
  * This fragment shows the the status of the Mars real-estate web services transaction.
@@ -42,7 +43,10 @@ class OverviewFragment : Fragment() {
      */
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
-        val binding = FragmentOverviewBinding.inflate(inflater)
+
+        //inflate the grid view item instead of the overview fragment
+        //this will show the grid item instead of the text view with the img url
+        val binding = GridViewItemBinding.inflate(inflater)
 
         // Allows Data Binding to Observe LiveData with the lifecycle of this Fragment
         binding.lifecycleOwner = this

--- a/app/src/main/java/com/example/android/marsrealestate/overview/OverviewViewModel.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/overview/OverviewViewModel.kt
@@ -33,12 +33,15 @@ import retrofit2.Response
  */
 class OverviewViewModel : ViewModel() {
 
-    // The internal MutableLiveData String that stores the status of the most recent request
-    private val _response = MutableLiveData<String>()
+    // the response liveData is primarily storing our errors, rename to status
+    private val _status = MutableLiveData<String>()
+    val status: LiveData<String>
+        get() = _status
 
-    // The external immutable LiveData for the request status String
-    val response: LiveData<String>
-        get() = _response
+    // the property LiveData stores the Mars property displayed
+    private val _property = MutableLiveData<MarsProperty>()
+    val property: LiveData<MarsProperty>
+        get() = _property
 
     /**
      * Call getMarsRealEstateProperties() on init so we can display status immediately.
@@ -52,13 +55,16 @@ class OverviewViewModel : ViewModel() {
      */
 
     private fun getMarsRealEstateProperties() {
-        //we run the getProperties call in a coroutine and take advantage of the error handling
         viewModelScope.launch {
             try {
                 var listResult = MarsApi.retrofitService.getProperties()
-                _response.value = "Success: ${listResult.size} Mars properties retrieved"
+                //set property value to first image in the list
+                if(listResult.isNotEmpty()) {
+                    _property.value = listResult[0]
+                }
+                _status.value = "Success: ${listResult.size} Mars properties retrieved"
             } catch (e: Exception) {
-                _response.value = "Failure: ${e.message}"
+                _status.value = "Failure: ${e.message}"
             }
         }
     }

--- a/app/src/main/res/layout/fragment_overview.xml
+++ b/app/src/main/res/layout/fragment_overview.xml
@@ -34,7 +34,7 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@{viewModel.response}"
+            android:text="@{viewModel.property.imgSrcUrl}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"

--- a/app/src/main/res/layout/grid_view_item.xml
+++ b/app/src/main/res/layout/grid_view_item.xml
@@ -20,6 +20,13 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="viewModel"
+            type="com.example.android.marsrealestate.overview.OverviewViewModel" />
+    </data>
+
     <ImageView
         android:id="@+id/mars_image"
         android:layout_width="match_parent"
@@ -27,5 +34,6 @@
         android:scaleType="centerCrop"
         android:adjustViewBounds="true"
         android:padding="2dp"
+        app:imageUrl="@{viewModel.property.imgSrcUrl}"
         tools:src="@tools:sample/backgrounds/scenic"/>
 </layout>


### PR DESCRIPTION
- In OverviewViewModel.kt,
   - rename response to status
   - store the first property in property live data
- In BindingAdapters.kt,
   - create a BindingAdapter to convert image URL to a URI with https scheme and use Glide library to display the image in an image view
   - apply request options to the Glide call to show a placeholder image while loading the image and an error image if loading fails
- In grid_view_item.xml,
   - add a viewModel data variable
   - bind mars_image to the inageView using the recently added binding adapter and inflate the grid view item in the overview fragment 