### PR TITLE
[Step 5] adds recycler view for the mars images

### DIFF
--- a/app/src/main/java/com/example/android/marsrealestate/BindingAdapters.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/BindingAdapters.kt
@@ -20,36 +20,33 @@ package com.example.android.marsrealestate
 import android.widget.ImageView
 import androidx.core.net.toUri
 import androidx.databinding.BindingAdapter
+import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
+import com.example.android.marsrealestate.network.MarsProperty
+import com.example.android.marsrealestate.overview.PhotoGridAdapter
+
+// use a binding adapter to initialize our photo grid adapter with list data
+// using a binding adapter to set the RecyclerView data will cause data binding to
+// automatically observe the LiveData for the list of Mars properties on our behalf
+@BindingAdapter("listData")
+fun bindRecyclerView(recyclerView: RecyclerView, data: List<MarsProperty>?) {
+    val adapter = recyclerView.adapter as PhotoGridAdapter
+    adapter.submitList(data)
+}
 
 // binding adapter takes the URL from an XML attribute associated with an ImgView
 // Uses Glide to load the image
-
-// this tells data binding that we want this binding adapter executed when an XML item
-// has the imageUrl attribute
 @BindingAdapter("imageUrl")
-// the view parameter is specified as an image view
 fun bindImage(imgView: ImageView, imgUrl: String?) {
     imgUrl?.let {
-        // convert image url to a uri
-        // make sure the resulting uri has the https scheme
         val imgUri = it.toUri().buildUpon().scheme("https").build()
-
-        // Glide has a fluent interface
-        // to load an image with Glide
-        // pass in an android context for the img view
         Glide.with(imgView.context)
             .load(imgUri)
-            // Glide can help us improve the user experience by showing
-            // a placeholder image while loading the image and an error image if the loading fails
-            // Glide adds these objects to the request using a RequestOptions object
             .apply(
                 RequestOptions()
                 .placeholder(R.drawable.loading_animation)
                 .error(R.drawable.ic_broken_image))
             .into(imgView)
-
     }
-
 }

--- a/app/src/main/java/com/example/android/marsrealestate/overview/OverviewFragment.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/overview/OverviewFragment.kt
@@ -44,9 +44,8 @@ class OverviewFragment : Fragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
 
-        //inflate the grid view item instead of the overview fragment
-        //this will show the grid item instead of the text view with the img url
-        val binding = GridViewItemBinding.inflate(inflater)
+        // recycler view will be in the overview fragment
+        val binding = FragmentOverviewBinding.inflate(inflater)
 
         // Allows Data Binding to Observe LiveData with the lifecycle of this Fragment
         binding.lifecycleOwner = this
@@ -54,6 +53,8 @@ class OverviewFragment : Fragment() {
         // Giving the binding access to the OverviewViewModel
         binding.viewModel = viewModel
 
+        // set photoGridAdapter to the binding
+        binding.photosGrid.adapter = PhotoGridAdapter()
         setHasOptionsMenu(true)
         return binding.root
     }

--- a/app/src/main/java/com/example/android/marsrealestate/overview/OverviewViewModel.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/overview/OverviewViewModel.kt
@@ -38,10 +38,10 @@ class OverviewViewModel : ViewModel() {
     val status: LiveData<String>
         get() = _status
 
-    // the property LiveData stores the Mars property displayed
-    private val _property = MutableLiveData<MarsProperty>()
-    val property: LiveData<MarsProperty>
-        get() = _property
+    // update to store a list of Mars properties
+    private val _properties = MutableLiveData<List<MarsProperty>>()
+    val properties: LiveData<List<MarsProperty>>
+        get() = _properties
 
     /**
      * Call getMarsRealEstateProperties() on init so we can display status immediately.
@@ -58,9 +58,9 @@ class OverviewViewModel : ViewModel() {
         viewModelScope.launch {
             try {
                 var listResult = MarsApi.retrofitService.getProperties()
-                //set property value to first image in the list
+                //set properties value to properties list
                 if(listResult.isNotEmpty()) {
-                    _property.value = listResult[0]
+                    _properties.value = listResult
                 }
                 _status.value = "Success: ${listResult.size} Mars properties retrieved"
             } catch (e: Exception) {

--- a/app/src/main/java/com/example/android/marsrealestate/overview/PhotoGridAdapter.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/overview/PhotoGridAdapter.kt
@@ -16,3 +16,49 @@
  */
 
 package com.example.android.marsrealestate.overview
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.example.android.marsrealestate.databinding.GridViewItemBinding
+import com.example.android.marsrealestate.network.MarsProperty
+
+// create a photo grid adapter
+// we are gonna extend RecyclerView list adapter, pass in the list item type, view holder and the diff util item callback
+class PhotoGridAdapter : ListAdapter<MarsProperty, PhotoGridAdapter.MarsPropertyViewHolder>(DiffCallback) {
+    // creates mars property view holder
+    // base view holder class requires a view in its constructor so we pass in the binding root view
+    // bind method binds the property to the binding class
+    class MarsPropertyViewHolder(private var binding: GridViewItemBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(marsProperty: MarsProperty) {
+            binding.property = marsProperty
+            binding.executePendingBindings()
+        }
+    }
+
+    // companion object is in the namespace of our class, but does not need a reference
+    companion object DiffCallback : DiffUtil.ItemCallback<MarsProperty>() {
+        override fun areItemsTheSame(oldItem: MarsProperty, newItem: MarsProperty): Boolean {
+            return oldItem === newItem
+        }
+
+        override fun areContentsTheSame(oldItem: MarsProperty, newItem: MarsProperty): Boolean {
+            return oldItem.id == newItem.id
+        }
+    }
+
+    // returns a new Mars property view holder created by inflating our grid view item binding
+    // using the layout inflater from our parent view group context
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PhotoGridAdapter.MarsPropertyViewHolder {
+        return MarsPropertyViewHolder(GridViewItemBinding.inflate(LayoutInflater.from(parent.context)))
+    }
+
+    // call getItem to get the Mars property associated with the RecyclerView position
+    // and bind it to the holder
+    override fun onBindViewHolder(holder: PhotoGridAdapter.MarsPropertyViewHolder, position: Int) {
+        val marsProperty = getItem(position)
+        holder.bind(marsProperty)
+    }
+}

--- a/app/src/main/res/layout/fragment_overview.xml
+++ b/app/src/main/res/layout/fragment_overview.xml
@@ -31,14 +31,24 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context="com.example.android.marsrealestate.MainActivity">
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@{viewModel.property.imgSrcUrl}"
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/photos_grid"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:padding="6dp"
+            android:clipToPadding="false"
+            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0"
+            app:listData="@{viewModel.properties}"
+            app:spanCount="2"
+            tools:itemCount="16"
+            tools:listitem="@layout/grid_view_item" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/grid_view_item.xml
+++ b/app/src/main/res/layout/grid_view_item.xml
@@ -22,11 +22,13 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+        <!-- replace the view model variable with a property of type MarsProperty  -->
         <variable
-            name="viewModel"
-            type="com.example.android.marsrealestate.overview.OverviewViewModel" />
+            name="property"
+            type="com.example.android.marsrealestate.network.MarsProperty" />
     </data>
 
+    <!-- image view now refers to a single property -->
     <ImageView
         android:id="@+id/mars_image"
         android:layout_width="match_parent"
@@ -34,6 +36,7 @@
         android:scaleType="centerCrop"
         android:adjustViewBounds="true"
         android:padding="2dp"
-        app:imageUrl="@{viewModel.property.imgSrcUrl}"
+        app:imageUrl="@{property.imgSrcUrl}"
         tools:src="@tools:sample/backgrounds/scenic"/>
+
 </layout>


### PR DESCRIPTION
- In OverviewViewModel, rename property to properties and update getMarsRealEstateProperties to return list of properties
- In grid_view_item.xml, replace view model with property of type MarsProperty
- In OverviewFragment, inflate the overview fragment binding
- In fragment overview layout, replace text view with recycler view
- Implement the recycler view adapter in PhotoGridAdapter.kt
    - Implement DiffCallback
    - Implement bind method to bind property to initial view holder
    - Implement onCreateViewHolder to create view holder from grid view item binding
    - Implement onBindViewHolder to bind property at an associated position
- In bindingAdapters, use a binding adapter to initialize our photo grid adapter with list data
- In the overview fragment layout,
    - bind the list data binding adapter to the list of properties
    - set clipToPadding to false
- In overview fragment, set adapter in recycler view to new PhotoGridAdapter