### PR TITLE
[Step 6] adds error handling and status images

### DIFF
--- a/app/src/main/java/com/example/android/marsrealestate/BindingAdapters.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/BindingAdapters.kt
@@ -17,6 +17,7 @@
 
 package com.example.android.marsrealestate
 
+import android.view.View
 import android.widget.ImageView
 import androidx.core.net.toUri
 import androidx.databinding.BindingAdapter
@@ -24,6 +25,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
 import com.example.android.marsrealestate.network.MarsProperty
+import com.example.android.marsrealestate.overview.MarsApiStatus
 import com.example.android.marsrealestate.overview.PhotoGridAdapter
 
 // use a binding adapter to initialize our photo grid adapter with list data
@@ -48,5 +50,24 @@ fun bindImage(imgView: ImageView, imgUrl: String?) {
                 .placeholder(R.drawable.loading_animation)
                 .error(R.drawable.ic_broken_image))
             .into(imgView)
+    }
+}
+
+//add binding adapter to show status in the image view
+//set view's visibility depending on the status value
+@BindingAdapter("marsApiStatus")
+fun bindStatus(statusImageView: ImageView, status: MarsApiStatus?) {
+    when (status) {
+        MarsApiStatus.LOADING -> {
+            statusImageView.visibility = View.VISIBLE
+            statusImageView.setImageResource(R.drawable.loading_animation)
+        }
+        MarsApiStatus.ERROR -> {
+            statusImageView.visibility = View.VISIBLE
+            statusImageView.setImageResource(R.drawable.ic_connection_error)
+        }
+        MarsApiStatus.DONE -> {
+            statusImageView.visibility = View.GONE
+        }
     }
 }

--- a/app/src/main/java/com/example/android/marsrealestate/overview/OverviewViewModel.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/overview/OverviewViewModel.kt
@@ -28,14 +28,22 @@ import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 
+// we want to add some basic error handling into the app so the user has a better idea of what happened
+// if the internet is not available, we will show our connection error icon and will show the loading animation
+// while fetching the Mars property list
+
+// we need to create a liveData in our view model to represent the status of our web request
+
+enum class MarsApiStatus { LOADING, ERROR, DONE }
+
 /**
  * The [ViewModel] that is attached to the [OverviewFragment].
  */
 class OverviewViewModel : ViewModel() {
 
-    // the response liveData is primarily storing our errors, rename to status
-    private val _status = MutableLiveData<String>()
-    val status: LiveData<String>
+    //we change the status to type MarsApiStatus
+    private val _status = MutableLiveData<MarsApiStatus>()
+    val status: LiveData<MarsApiStatus>
         get() = _status
 
     // update to store a list of Mars properties
@@ -55,16 +63,15 @@ class OverviewViewModel : ViewModel() {
      */
 
     private fun getMarsRealEstateProperties() {
+        // update coroutine calls to update status accordingly
         viewModelScope.launch {
+            _status.value = MarsApiStatus.LOADING
             try {
-                var listResult = MarsApi.retrofitService.getProperties()
-                //set properties value to properties list
-                if(listResult.isNotEmpty()) {
-                    _properties.value = listResult
-                }
-                _status.value = "Success: ${listResult.size} Mars properties retrieved"
+                _properties.value = MarsApi.retrofitService.getProperties()
+                _status.value = MarsApiStatus.DONE
             } catch (e: Exception) {
-                _status.value = "Failure: ${e.message}"
+                _status.value = MarsApiStatus.ERROR
+                _properties.value = ArrayList()
             }
         }
     }

--- a/app/src/main/res/layout/fragment_overview.xml
+++ b/app/src/main/res/layout/fragment_overview.xml
@@ -50,5 +50,16 @@
             tools:itemCount="16"
             tools:listitem="@layout/grid_view_item" />
 
+        <!-- Add status image view to constraint layout-->
+        <ImageView
+            android:id="@+id/status_image"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:marsApiStatus="@{viewModel.status}" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
- In OverviewViewModel.kt, create a MarsApiStatus enum class
- Change status to type MarsApiStatus
- Use status in getMarsRealEstateProperties, clear the properties when error status occurs
- Add a binding adapter to show MarsApiStatus in image view and set visibility accordingly
- Add status image view to overview fragment layout