### PR TITLE
[Step 7] adds detail screen and associated functionality

### DIFF
--- a/app/src/main/java/com/example/android/marsrealestate/detail/DetailFragment.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/detail/DetailFragment.kt
@@ -35,6 +35,19 @@ class DetailFragment : Fragment() {
         val application = requireNotNull(activity).application
         val binding = FragmentDetailBinding.inflate(inflater)
         binding.lifecycleOwner = this
+
+        // get selected property from the fragment arguments
+        // throws a null pointer exception if argument is null
+        val marsProperty = DetailFragmentArgs.fromBundle(arguments!!).selectedProperty
+
+        // we need to use a custom details View model factory to get an instance
+        // of the detail view model that takes a property as an argument
+        val viewModelFactory = DetailViewModelFactory(marsProperty, application)
+
+        // set the view model in the binding using the view model factory
+        binding.viewModel = ViewModelProvider(
+            this, viewModelFactory).get(DetailViewModel::class.java)
+
         return binding.root
     }
 }

--- a/app/src/main/java/com/example/android/marsrealestate/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/detail/DetailViewModel.kt
@@ -17,13 +17,42 @@
 package com.example.android.marsrealestate.detail
 
 import android.app.Application
-import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.*
+import com.example.android.marsrealestate.R
 import com.example.android.marsrealestate.detail.DetailFragment
 import com.example.android.marsrealestate.network.MarsProperty
 
 /**
  * The [ViewModel] that is associated with the [DetailFragment].
  */
-class DetailViewModel(@Suppress("UNUSED_PARAMETER")marsProperty: MarsProperty, app: Application) : AndroidViewModel(app) {
+class DetailViewModel(marsProperty: MarsProperty, app: Application) : AndroidViewModel(app) {
+
+    // selected property live data that stores the selected property
+    private val _selectedProperty = MutableLiveData<MarsProperty>()
+    val selectedProperty: LiveData<MarsProperty>
+        get() = _selectedProperty
+
+    // initialize selected property with passed in mars property object
+    init {
+        _selectedProperty.value = marsProperty
+    }
+
+    // creates displayed property price based on if it is a rental
+    val displayPropertyPrice = Transformations.map(selectedProperty) {
+        app.applicationContext.getString(
+            when (it.isRental) {
+                true -> R.string.display_price_monthly_rental
+                false -> R.string.display_price
+            }, it.price)
+    }
+
+    // creates displayed property type strings based on if it is a rental
+    val displayPropertyType = Transformations.map(selectedProperty) {
+        app.applicationContext.getString(R.string.display_type,
+            app.applicationContext.getString(
+                when(it.isRental) {
+                    true -> R.string.type_rent
+                    false -> R.string.type_sale
+                }))
+    }
 }

--- a/app/src/main/java/com/example/android/marsrealestate/network/MarsProperty.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/network/MarsProperty.kt
@@ -17,15 +17,20 @@
 
 package com.example.android.marsrealestate.network
 
+import android.os.Parcelable
 import com.squareup.moshi.Json
+import kotlinx.android.parcel.Parcelize
 
 //Moshi needs to have a class to store the parsed JSON
 //Moshi will match the property names from the MarsProperty class with the property names from the JSON response
-
+@Parcelize
 data class MarsProperty(
     val id: String,
-    //we use the @JSON annotation to switch the name of the property to match Kotlin style
+    // used to map img_src from the JSON to imgSrcUrl in our class
     @Json(name = "img_src") val imgSrcUrl: String,
     val type: String,
-    val price: Double
-)
+    val price: Double) : Parcelable {
+    // adds isRental boolean value dependent on type of property
+    val isRental
+        get() = type == "rent"
+}

--- a/app/src/main/java/com/example/android/marsrealestate/overview/OverviewFragment.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/overview/OverviewFragment.kt
@@ -20,7 +20,9 @@ package com.example.android.marsrealestate.overview
 import android.os.Bundle
 import android.view.*
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.fragment.findNavController
 import com.example.android.marsrealestate.R
 import com.example.android.marsrealestate.databinding.FragmentOverviewBinding
 import com.example.android.marsrealestate.databinding.GridViewItemBinding
@@ -53,8 +55,20 @@ class OverviewFragment : Fragment() {
         // Giving the binding access to the OverviewViewModel
         binding.viewModel = viewModel
 
-        // set photoGridAdapter to the binding
-        binding.photosGrid.adapter = PhotoGridAdapter()
+        // Initialize PhotoGridAdapter with an OnClickListener that calls viewModel.displayPropertyDetails
+        // Sets the adapter of the photosGrid RecyclerView
+        binding.photosGrid.adapter = PhotoGridAdapter(PhotoGridAdapter.OnClickListener {
+            viewModel.displayPropertyDetails(it)
+        })
+
+        // observes navigation being triggered, navigates, and sets navigateToSelectedProperty to null
+        viewModel.navigateToSelectedProperty.observe(this, Observer {
+            if ( null != it ) {
+                this.findNavController().navigate(OverviewFragmentDirections.actionShowDetail(it))
+                viewModel.displayPropertyDetailsComplete()
+            }
+        })
+
         setHasOptionsMenu(true)
         return binding.root
     }

--- a/app/src/main/java/com/example/android/marsrealestate/overview/OverviewViewModel.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/overview/OverviewViewModel.kt
@@ -51,6 +51,11 @@ class OverviewViewModel : ViewModel() {
     val properties: LiveData<List<MarsProperty>>
         get() = _properties
 
+    // add a live data for triggering navigation to the selected property
+    private val _navigateToSelectedProperty = MutableLiveData<MarsProperty>()
+    val navigateToSelectedProperty: LiveData<MarsProperty>
+        get() = _navigateToSelectedProperty
+
     /**
      * Call getMarsRealEstateProperties() on init so we can display status immediately.
      */
@@ -74,5 +79,15 @@ class OverviewViewModel : ViewModel() {
                 _properties.value = ArrayList()
             }
         }
+    }
+
+    // function sets the navigateToSelectedProperty to the selected property
+    fun displayPropertyDetails(marsProperty: MarsProperty) {
+        _navigateToSelectedProperty.value = marsProperty
+    }
+
+    // function sets the navigateToSelectedProperty to null when navigation is complete
+    fun displayPropertyDetailsComplete() {
+        _navigateToSelectedProperty.value = null
     }
 }

--- a/app/src/main/java/com/example/android/marsrealestate/overview/PhotoGridAdapter.kt
+++ b/app/src/main/java/com/example/android/marsrealestate/overview/PhotoGridAdapter.kt
@@ -25,12 +25,10 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.android.marsrealestate.databinding.GridViewItemBinding
 import com.example.android.marsrealestate.network.MarsProperty
 
-// create a photo grid adapter
-// we are gonna extend RecyclerView list adapter, pass in the list item type, view holder and the diff util item callback
-class PhotoGridAdapter : ListAdapter<MarsProperty, PhotoGridAdapter.MarsPropertyViewHolder>(DiffCallback) {
-    // creates mars property view holder
-    // base view holder class requires a view in its constructor so we pass in the binding root view
-    // bind method binds the property to the binding class
+// add onClickListener class as a constructor parameter
+class PhotoGridAdapter(val onClickListener: OnClickListener) :
+    ListAdapter<MarsProperty, PhotoGridAdapter.MarsPropertyViewHolder>(DiffCallback) {
+
     class MarsPropertyViewHolder(private var binding: GridViewItemBinding) : RecyclerView.ViewHolder(binding.root) {
         fun bind(marsProperty: MarsProperty) {
             binding.property = marsProperty
@@ -38,7 +36,6 @@ class PhotoGridAdapter : ListAdapter<MarsProperty, PhotoGridAdapter.MarsProperty
         }
     }
 
-    // companion object is in the namespace of our class, but does not need a reference
     companion object DiffCallback : DiffUtil.ItemCallback<MarsProperty>() {
         override fun areItemsTheSame(oldItem: MarsProperty, newItem: MarsProperty): Boolean {
             return oldItem === newItem
@@ -49,16 +46,21 @@ class PhotoGridAdapter : ListAdapter<MarsProperty, PhotoGridAdapter.MarsProperty
         }
     }
 
-    // returns a new Mars property view holder created by inflating our grid view item binding
-    // using the layout inflater from our parent view group context
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PhotoGridAdapter.MarsPropertyViewHolder {
         return MarsPropertyViewHolder(GridViewItemBinding.inflate(LayoutInflater.from(parent.context)))
     }
 
-    // call getItem to get the Mars property associated with the RecyclerView position
-    // and bind it to the holder
     override fun onBindViewHolder(holder: PhotoGridAdapter.MarsPropertyViewHolder, position: Int) {
         val marsProperty = getItem(position)
+        // call onClick function from the onClickListener
+        holder.itemView.setOnClickListener {
+            onClickListener.onClick(marsProperty)
+        }
         holder.bind(marsProperty)
+    }
+
+    // create an onClickListener that creates a named onClick function
+    class OnClickListener(val clickListener: (marsProperty: MarsProperty) -> Unit) {
+        fun onClick(marsProperty:MarsProperty) = clickListener(marsProperty)
     }
 }

--- a/app/src/main/res/layout/fragment_detail.xml
+++ b/app/src/main/res/layout/fragment_detail.xml
@@ -21,6 +21,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- add data declaration for detail view model-->
+    <data>
+        <variable
+            name="viewModel"
+            type="com.example.android.marsrealestate.detail.DetailViewModel" />
+    </data>
+
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -31,6 +38,7 @@
             android:layout_height="wrap_content"
             android:padding="16dp">
 
+            <!-- add image url to image view for selected property-->
             <ImageView
                 android:id="@+id/main_photo_image"
                 android:layout_width="0dp"
@@ -39,8 +47,11 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
+                app:imageUrl="@{viewModel.selectedProperty.imgSrcUrl}"
                 tools:src="@tools:sample/backgrounds/scenic" />
 
+            <!-- add property type and property price for selected property-->
+            <!-- update the property type and property price to formatted strings-->d
             <TextView
                 android:id="@+id/property_type_text"
                 android:layout_width="wrap_content"
@@ -48,6 +59,7 @@
                 android:layout_marginTop="16dp"
                 android:textColor="#de000000"
                 android:textSize="39sp"
+                android:text="@{viewModel.displayPropertyType}"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/main_photo_image"
                 tools:text="To Rent" />
@@ -59,6 +71,7 @@
                 android:layout_marginTop="8dp"
                 android:textColor="#de000000"
                 android:textSize="20sp"
+                android:text="@{viewModel.displayPropertyPrice}"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/property_type_text"
                 tools:text="$100,000" />

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -38,6 +38,10 @@
         android:name="com.example.android.marsrealestate.detail.DetailFragment"
         android:label="fragment_detail"
         tools:layout="@layout/fragment_detail">
+        <!-- Add selectedProperty argument of type MarsProperty -->
+        <argument
+            android:name="selectedProperty"
+            app:argType="com.example.android.marsrealestate.network.MarsProperty"/>
     </fragment>
 
 </navigation>


### PR DESCRIPTION
- DetailViewModel.kt
   - add selectedProperty live data and initialize it
   - create transformation map, displayPropertyPrice, to display price based on if it is a rental
   - create transformation map, displayPropertyType,  to display whether property is for sale or rent
- fragment_detail.xml
   - add view model as a data block to the detail fragment layout
   - add imgSrcUrl for selected property to image view
   - replace text views with transformations for displayPropertyPrice and displayPropertyType
- OverviewViewModel.kt
   - add navigateToSelectedProperty live data for triggering navigation
   - displayPropertyDetails sets navigateToSelectedProperty to marsProperty and initiates navigation to detail screen
   - displayPropertyDetailsComplete sets navigateToSelectedProperty to null
- PhotoGridAdapter.kt
   - create an internal OnClickListener class with a lambda in its constructor that initializes a matching onClick function
   - add onClickListener parameter to PhotoGridAdapter
   - set up onClickListener to pass marsProperty on button click in onBindViewHolder
- OverviewFragment.kt
   - update the PhotoGridAdapter binding by adding a click listener that passes the selected property to displayPropertyDetails
   - add observer to trigger navigation to the detail screen when marsProperty is not null
- MarsProperty class 
   - Make MarsProperty parcelable
   - create an isRental boolean
- In nav_graph.xml, add an argument selectedProperty passed  to  detailFragment
- DetailFragment.kt
   - create marsProperty from the passed argument
   - use it to create a DetailViewModelFactory
   - use the factory to create a DetailViewModel and bind it to viewModel
-     